### PR TITLE
replaced occurences of exprs by logcounts in help pages

### DIFF
--- a/man/computeSumFactors.Rd
+++ b/man/computeSumFactors.Rd
@@ -28,7 +28,7 @@
 \item{subset.row}{A logical, integer or character scalar indicating the rows of \code{x} to use.}
 \item{no.warn}{A logical scalar indicating whether a warning should be generated when both \code{min.mean} and \code{subset.row} are specified.}
 \item{...}{Additional arguments to pass to \code{computeSumFactors,ANY-method}.}
-\item{assay.type}{A string specifying which assay values to use, e.g., \code{counts} or \code{exprs}.}
+\item{assay.type}{A string specifying which assay values to use, e.g., \code{counts} or \code{logcounts}.}
 \item{get.spikes}{A logical scalar specifying whether spike-in transcripts should be used.}
 \item{sf.out}{A logical scalar indicating whether only size factors should be returned.}
 }
@@ -81,7 +81,7 @@ However, this has known problems when the linear system becomes too large (see \
 In such cases, set \code{clusters} to break up the linear system into smaller, more manageable components that can be solved separately.
 }
 
-\section{Dealing with negative size factors}{ 
+\section{Dealing with negative size factors}{
 In theory, it is possible to obtain negative estimates for the size factors.
 These values are obviously nonsensical and \code{computeSumFactors} will raise a warning if they are encountered.
 Negative estimates are mostly commonly generated from low quality cells with few expressed features, such that most counts are zero even after pooling.
@@ -105,12 +105,12 @@ Such occurrences are unavoidable -- rather, the aim is to prevent negative value
 
 \section{Gene selection}{
 By default, \code{get.spikes=FALSE} in \code{quickCluster,SingleCellExperiment-method} which means that spike-in transcripts are not included in the set of genes used for deconvolution.
-This is because they can behave differently from the endogenous genes. 
+This is because they can behave differently from the endogenous genes.
 Users wanting to perform spike-in normalization should see \code{\link{computeSpikeFactors}} instead.
 
 Users can also set \code{subset.row} to specify which rows of \code{x} are to be used to calculate correlations.
 This is equivalent to but more efficient than subsetting \code{x} directly, as it avoids constructing a (potentially large) temporary matrix.
-If \code{subset.row} is specified and \code{get.spikes=FALSE}, only the non-spike-in entries of \code{subset.row} will be used in deconvolution. 
+If \code{subset.row} is specified and \code{get.spikes=FALSE}, only the non-spike-in entries of \code{subset.row} will be used in deconvolution.
 
 Note that pooling does not eliminate the need to filter out low-abundance genes.
 As mentioned above, if too many genes have consistently low counts across all cells, even the pool-based size factors will be zero.

--- a/man/correlatePairs.Rd
+++ b/man/correlatePairs.Rd
@@ -8,11 +8,11 @@
 \description{Identify pairs of genes that are significantly correlated based on a modified Spearman's rho.}
 
 \usage{
-correlateNull(ncells, iters=1e6, design=NULL, residuals=FALSE) 
+correlateNull(ncells, iters=1e6, design=NULL, residuals=FALSE)
 
-\S4method{correlatePairs}{ANY}(x, null.dist=NULL, tol=1e-8, iters=1e6, 
+\S4method{correlatePairs}{ANY}(x, null.dist=NULL, tol=1e-8, iters=1e6,
     design=NULL, residuals=FALSE, lower.bound=NULL,
-    use.names=TRUE, subset.row=NULL, pairings=NULL, per.gene=FALSE,  
+    use.names=TRUE, subset.row=NULL, pairings=NULL, per.gene=FALSE,
     block.size=100L, BPPARAM=SerialParam())
 
 \S4method{correlatePairs}{SingleCellExperiment}(x, ..., use.names=TRUE, subset.row=NULL, per.gene=FALSE,
@@ -32,7 +32,7 @@ correlateNull(ncells, iters=1e6, design=NULL, residuals=FALSE)
 \item{BPPARAM}{A BiocParallelParam object to use in \code{bplapply} for parallel processing.}
 \item{tol}{A numeric scalar indicating the maximum difference under which two expression values are tied.}
 \item{use.names}{
-    A logical scalar specifying whether the row names of \code{exprs} should be used in the output.
+    A logical scalar specifying whether the row names of \code{assay.type} should be used in the output.
     Alternatively, a character vector containing the names to use.
 }
 \item{subset.row}{A logical, integer or character vector indicating the rows of \code{x} to use to compute correlations.}
@@ -67,8 +67,8 @@ Correction for multiple testing is done using the BH method.
 % Yeah, we could use a t-distribution for this, but the empirical distribution is probably more robust if you have few cells (or effects, after batch correction).
 
 For \code{correlatePairs}, a pre-computed empirical distribution can be supplied as \code{null.dist} if available.
-Otherwise, it will be automatically constructed via \code{correlateNull} with \code{ncells} set to the number of columns in \code{exprs}.
-For \code{correlatePairs,SingleCellExperiment-method}, correlations should be computed for normalized expression values in the specified \code{assay.type}. 
+Otherwise, it will be automatically constructed via \code{correlateNull} with \code{ncells} set to the number of columns in \code{assay.type}.
+For \code{correlatePairs,SingleCellExperiment-method}, correlations should be computed for normalized expression values in the specified \code{assay.type}.
 
 The lower bound of the p-values is determined by the value of \code{iters}.
 If the \code{limited} field is \code{TRUE} in the returned dataframe, it may be possible to obtain lower p-values by increasing \code{iters}.
@@ -94,7 +94,7 @@ For \code{correlatePairs} with \code{per.gene=FALSE}, a dataframe is returned wi
 \item{\code{rho}:}{A numeric field containing the approximate Spearman's rho.}
 \item{\code{p.value, FDR}:}{Numeric fields containing the permutation p-value and its BH-corrected equivalent.}
 \item{\code{limited}:}{A logical scalar indicating whether the p-value is at its lower bound, defined by \code{iters}.}
-} 
+}
 Rows are sorted by increasing \code{p.value} and, if tied, decreasing absolute size of \code{rho}.
 The exception is if \code{subset.row} is a matrix, in which case each row in the dataframe correspond to a row of \code{subset.row}.
 
@@ -149,7 +149,7 @@ For example, we could select only HVGs to focus on genes contributing to cell-to
 There is no need to account for HVG pre-selection in multiple testing, because rank correlations are unaffected by the variance.
 
 Lowly-expressed genes can also cause problems when \code{design} is non-\code{NULL} and \code{residuals=TRUE}.
-Tied counts, and zeroes in particular, may not result in tied residuals after fitting of the linear model. 
+Tied counts, and zeroes in particular, may not result in tied residuals after fitting of the linear model.
 Model fitting may break ties in a consistent manner across genes, yielding large correlations between genes with many zero counts.
 Focusing on HVGs should mitigate the detection of these uninteresting correlations, as genes dominated by zeroes will usually have low variance.
 }
@@ -176,8 +176,8 @@ Phipson B and Smyth GK (2010).
 Permutation P-values should never be zero: calculating exact P-values when permutations are randomly drawn.
 \emph{Stat. Appl. Genet. Mol. Biol.} 9:Article 39.
 
-Simes RJ (1986). 
-An improved Bonferroni procedure for multiple tests of significance. 
+Simes RJ (1986).
+An improved Bonferroni procedure for multiple tests of significance.
 \emph{Biometrika} 73:751-754.
 }
 
@@ -187,7 +187,7 @@ ncells <- 100
 null.dist <- correlateNull(ncells, iters=100000)
 exprs <- matrix(rpois(ncells*100, lambda=10), ncol=ncells)
 out <- correlatePairs(exprs, null.dist=null.dist)
-hist(out$p.value) 
+hist(out$p.value)
 }
 
 \keyword{

--- a/man/cyclone.Rd
+++ b/man/cyclone.Rd
@@ -7,7 +7,7 @@
 \description{Classify single cells into their cell cycle phases based on gene expression data.}
 
 \usage{
-\S4method{cyclone}{ANY}(x, pairs, gene.names=rownames(x), iter=1000, min.iter=100, min.pairs=50, 
+\S4method{cyclone}{ANY}(x, pairs, gene.names=rownames(x), iter=1000, min.iter=100, min.pairs=50,
     BPPARAM=SerialParam(), verbose=FALSE, subset.row=NULL)
 
 \S4method{cyclone}{SingleCellExperiment}(x, pairs, subset.row=NULL, ..., assay.type="counts", get.spikes=FALSE)
@@ -27,7 +27,7 @@
 \item{verbose}{A logical scalar specifying whether diagnostics should be printed to screen.}
 \item{subset.row}{A logical, integer or character scalar indicating the rows of \code{x} to use.}
 \item{...}{Additional arguments to pass to \code{cyclone,ANY-method}.}
-\item{assay.type}{A string specifying which assay values to use, e.g., \code{counts} or \code{exprs}.}
+\item{assay.type}{A string specifying which assay values to use, e.g., \code{counts} or \code{logcounts}.}
 \item{get.spikes}{A logical specifying whether spike-in transcripts should be used.}
 }
 
@@ -40,7 +40,7 @@ For each cell, \code{cyclone} calculates the proportion of all marker pairs wher
 A high proportion suggests that the cell is likely to belong in G1 phase, as the expression ranking in the new data is consistent with that in the training data.
 
 Proportions are not directly comparable between phases due to the use of different sets of gene pairs for each phase.
-Instead, proportions are converted into scores (see below) that account for the size and precision of the proportion estimate. 
+Instead, proportions are converted into scores (see below) that account for the size and precision of the proportion estimate.
 The same process is repeated for all phases, using the corresponding set of marker pairs in \code{pairs}.
 Cells with G1 or G2M scores above 0.5 are assigned to the G1 or G2M phases, respectively.
 (If both are above 0.5, the higher score is used for assignment.)
@@ -59,10 +59,10 @@ However, for non-cell cycle phase groupings, the output \code{phases} will be an
 Users should manually apply their own score thresholds for assigning cells into specific groups.
 }
 
-\section{Description of the score calculation}{ 
+\section{Description of the score calculation}{
 To make the proportions comparable between phases, a distribution of proportions is constructed by shuffling the expression values within each cell and recalculating the proportion.
 The phase score is defined as the lower tail probability at the observed proportion.
-High scores indicate that the proportion is greater than what is expected by chance if the expression of marker genes were independent 
+High scores indicate that the proportion is greater than what is expected by chance if the expression of marker genes were independent
 (i.e., with no cycle-induced correlations between marker pairs within each cell).
 
 % The shuffling assumes that the marker genes are IID from the same distribution of expression values, such that there's no correlations.
@@ -87,7 +87,7 @@ This modification aims to use the most relevant expression values to build the n
 \value{
 A list is returned containing:
 \describe{
-\item{\code{phases}:}{A character vector containing the predicted phase for each cell.} 
+\item{\code{phases}:}{A character vector containing the predicted phase for each cell.}
 \item{\code{scores}:}{A data frame containing the numeric phase scores for each phase and cell (i.e., each row is a cell).}
 \item{\code{normalized.scores}:}{A data frame containing the row-normalized scores (i.e., where the row sum for each cell is equal to 1).}
 }
@@ -106,7 +106,7 @@ with modifications by Aaron Lun
 example(sandbag) # Using the mocked-up data in this example.
 
 # Classifying (note: test.data!=training.data in real cases)
-test <- training 
+test <- training
 assignments <- cyclone(test, out)
 head(assignments$scores)
 head(assignments$phases)
@@ -120,7 +120,7 @@ plot(assignments$score$G1, assignments$score$G2M, col=col, pch=16)
 }
 
 \references{
-Scialdone A, Natarajana KN, Saraiva LR et al. (2015). 
+Scialdone A, Natarajana KN, Saraiva LR et al. (2015).
 Computational assignment of cell-cycle stage from single-cell transcriptome data.
 \emph{Methods} 85:54--61
 }

--- a/man/exploreData.Rd
+++ b/man/exploreData.Rd
@@ -18,13 +18,13 @@ exploreData(x, cell.data, gene.data, red.dim, run=TRUE)
 
 \details{
 This function will return a Shiny app object that can be run with \code{\link{runApp}}.
-The app allows the user to interactively explore gene expression patterns in single-cell RNA-seq data. 
+The app allows the user to interactively explore gene expression patterns in single-cell RNA-seq data.
 Explorative analysis is focused on comparing gene exression between different groups of cells, as defined by the covariates of \code{cell.data}.
 
-Three plots are shown in the app: 
+Three plots are shown in the app:
 \itemize{
 \item a scatterplot of cell locations based on the \code{red.dim} coordinates, colored by a selected covariate
-\item a scatterplot of cell locations based on the \code{red.dim} coordinates, colored by expression of a selected gene 
+\item a scatterplot of cell locations based on the \code{red.dim} coordinates, colored by expression of a selected gene
 \item boxplot(s) of expression values for a selected gene, grouped by a selected covariate.
 }
 
@@ -58,11 +58,11 @@ gene.data <- DataFrame(lengths=runif(nrow(sce)))
 
 # Mocking up  some reduced dimensions.
 library(Rtsne)
-tsn <- Rtsne(t(exprs(sce)), perplexity=10)
+tsn <- Rtsne(t(logcounts(sce)), perplexity=10)
 red.dim <- tsn$Y[,1:2]
 
 # Creating the app object.
-app <- exploreData(exprs(sce), cell.data, gene.data, red.dim, run=FALSE)
+app <- exploreData(logcounts(sce), cell.data, gene.data, red.dim, run=FALSE)
 if (interactive()) { shiny::runApp(app) }
 
 \dontrun{# Running directly from the function.

--- a/man/findMarkers.Rd
+++ b/man/findMarkers.Rd
@@ -7,10 +7,10 @@
 \description{Find candidate marker genes for clusters of cells, by testing for differential expression between clusters.}
 
 \usage{
-\S4method{findMarkers}{ANY}(x, clusters, design=NULL, pval.type=c("any", "all"), 
+\S4method{findMarkers}{ANY}(x, clusters, design=NULL, pval.type=c("any", "all"),
     direction=c("any", "up", "down"), min.mean=0.1, subset.row=NULL)
 
-\S4method{findMarkers}{SingleCellExperiment}(x, ..., subset.row=NULL, assay.type="logcounts", get.spikes=FALSE) 
+\S4method{findMarkers}{SingleCellExperiment}(x, ..., subset.row=NULL, assay.type="logcounts", get.spikes=FALSE)
 }
 
 \arguments{
@@ -27,7 +27,7 @@ A vector of cluster identities for all cells.
 \item{min.mean}{A numeric scalar specifying the mean threshold for computing empirical Bayes parameters.}
 \item{subset.row}{A logical, integer or character scalar indicating the rows of \code{x} to use.}
 \item{...}{Additional arguments to pass to the matrix method.}
-\item{assay.type}{A string specifying which assay values to use, e.g., \code{counts} or \code{exprs}.}
+\item{assay.type}{A string specifying which assay values to use, e.g., \code{counts} or \code{logcounts}.}
 \item{get.spikes}{A logical scalar specifying whether decomposition should be performed for spike-ins.}
 }
 
@@ -72,7 +72,7 @@ Note that the presence of factors that are confounded with \code{clusters} will 
 \value{
 A named list of data frames, where each data frame corresponds to a cluster and contains a ranked set of potential marker genes.
 In each data frame, the log-fold change of the cluster against every other cluster Y is also reported, under the column named \code{logFC.Y}.
-} 
+}
 
 \author{
 Aaron Lun
@@ -83,23 +83,23 @@ Aaron Lun
 }
 
 \references{
-Law CW, Chen Y, Shi W and Smyth, GK (2014). 
-voom: precision weights unlock linear model analysis tools for RNA-seq read counts. 
-\emph{Genome Biol.} 15:R29 
+Law CW, Chen Y, Shi W and Smyth, GK (2014).
+voom: precision weights unlock linear model analysis tools for RNA-seq read counts.
+\emph{Genome Biol.} 15:R29
 
-Simes RJ (1986). 
-An improved Bonferroni procedure for multiple tests of significance. 
+Simes RJ (1986).
+An improved Bonferroni procedure for multiple tests of significance.
 \emph{Biometrika} 73:751-754.
 
-Berger RL and Hsu JC (1996). 
+Berger RL and Hsu JC (1996).
 Bioequivalence trials, intersection-union tests and equivalence confidence sets.
 \emph{Statist. Sci.} 11, 283-319.
 }
 
 \examples{
 # Using the mocked-up data 'y2' from this example.
-example(computeSpikeFactors) 
+example(computeSpikeFactors)
 y2 <- normalize(y2)
-kout <- kmeans(t(exprs(y2)), centers=2) # Any clustering method is okay.
+kout <- kmeans(t(logcounts(y2)), centers=2) # Any clustering method is okay.
 out <- findMarkers(y2, clusters=kout$cluster)
 }

--- a/man/overlapExprs.Rd
+++ b/man/overlapExprs.Rd
@@ -7,11 +7,11 @@
 \description{Compute the gene-specific overlap in expression profiles between two groups of cells.}
 
 \usage{
-\S4method{overlapExprs}{ANY}(x, groups, design=NULL, residuals=FALSE, tol=1e-8, 
+\S4method{overlapExprs}{ANY}(x, groups, design=NULL, residuals=FALSE, tol=1e-8,
     BPPARAM=SerialParam(), subset.row=NULL, lower.bound=NULL)
 
-\S4method{overlapExprs}{SingleCellExperiment}(x, ..., subset.row=NULL, lower.bound=NULL, 
-    assay.type="logcounts", get.spikes=FALSE) 
+\S4method{overlapExprs}{SingleCellExperiment}(x, ..., subset.row=NULL, lower.bound=NULL,
+    assay.type="logcounts", get.spikes=FALSE)
 }
 
 \arguments{
@@ -23,13 +23,13 @@
 A vector of group assignments for all cells.
 }
 \item{design}{A numeric matrix containing blocking terms, i.e., uninteresting factors driving expression across cells.}
-\item{residuals}{A logical scalar indicating whether overlaps should be computed between residuals of a linear model.} 
+\item{residuals}{A logical scalar indicating whether overlaps should be computed between residuals of a linear model.}
 \item{tol}{A numeric scalar specifying the tolerance with which ties are considered.}
 \item{BPPARAM}{A BiocParallelParam object to use in \code{bplapply} for parallel processing.}
 \item{subset.row}{A logical, integer or character scalar indicating the rows of \code{x} to use.}
 \item{lower.bound}{A numeric scalar specifying the theoretical lower bound of values in \code{x}, only used when \code{residuals=TRUE}.}
 \item{...}{Additional arguments to pass to the matrix method.}
-\item{assay.type}{A string specifying which assay values to use, e.g., \code{counts} or \code{exprs}.}
+\item{assay.type}{A string specifying which assay values to use, e.g., \code{counts} or \code{logcounts}.}
 \item{get.spikes}{A logical scalar specifying whether decomposition should be performed for spike-ins.}
 }
 
@@ -54,7 +54,7 @@ This is overridden by any non-\code{NULL} value of \code{subset.row}.
 \section{Accounting for uninteresting variation}{
 If the experiment has known (and uninteresting) factors of variation, these can be included in \code{design}.
 The approach used to remove these factors depends on the design matrix.
-If there is only one factor in \code{design}, the levels of the factor are defined as separate blocks. 
+If there is only one factor in \code{design}, the levels of the factor are defined as separate blocks.
 Overlaps between groups are computed within each block, and a weighted mean (based on the number of cells in each block) of the overlaps is taken across all blocks.
 
 This approach avoids the need for linear modelling and the associated assumptions regarding normality and correct model specification.
@@ -73,7 +73,7 @@ A named list of numeric matrices.
 Each matrix corresponds to a group (A) in \code{groups} and contains one row per gene in \code{x} (or the subset specified by \code{subset.row}).
 Each column corresponds to another group (B) in \code{groups}.
 The matrix entries contain overlap proportions between groups A and B for each gene.
-} 
+}
 
 \author{
 Aaron Lun
@@ -85,7 +85,7 @@ Aaron Lun
 
 \examples{
 # Using the mocked-up data 'y2' from this example.
-example(computeSpikeFactors) 
+example(computeSpikeFactors)
 y2 <- normalize(y2)
 groups <- sample(3, ncol(y2), replace=TRUE)
 out <- overlapExprs(y2, groups, subset.row=1:10)

--- a/man/quickCluster.Rd
+++ b/man/quickCluster.Rd
@@ -7,7 +7,7 @@
 \description{Cluster similar cells based on rank correlations in their gene expression profiles.}
 
 \usage{
-\S4method{quickCluster}{ANY}(x, min.size=200, max.size=NULL, subset.row=NULL, 
+\S4method{quickCluster}{ANY}(x, min.size=200, max.size=NULL, subset.row=NULL,
     get.ranks=FALSE, method=c("hclust", "igraph"), pc.approx=TRUE, ...)
 
 \S4method{quickCluster}{SingleCellExperiment}(x, subset.row=NULL, ..., assay.type="counts", get.spikes=FALSE)
@@ -25,11 +25,11 @@
 \item{method}{A string specifying the clustering method to use.}
 \item{pc.approx}{Argument passed to \code{\link{buildSNNGraph}} when \code{method="igraph"}, otherwise ignored.}
 \item{...}{
-    For \code{quickCluster,ANY-method}, additional arguments to be passed to \code{\link{cutreeDynamic}} for \code{method="hclust"}, 
+    For \code{quickCluster,ANY-method}, additional arguments to be passed to \code{\link{cutreeDynamic}} for \code{method="hclust"},
         or \code{\link{buildSNNGraph}} for \code{method="igraph"}.
     For \code{quickCluster,SingleCellExperiment-method}, additional arguments to pass to \code{quickCluster,ANY-method}.
 }
-\item{assay.type}{A string specifying which assay values to use, e.g., \code{counts} or \code{exprs}.}
+\item{assay.type}{A string specifying which assay values to use, e.g., \code{counts} or \code{logcounts}.}
 \item{get.spikes}{A logical specifying whether spike-in transcripts should be used.}
 }
 

--- a/man/sandbag.Rd
+++ b/man/sandbag.Rd
@@ -7,10 +7,10 @@
 \description{Use gene expression data to train a classifier for cell cycle phase.}
 
 \usage{
-\S4method{sandbag}{ANY}(x, phases, gene.names=rownames(x), 
+\S4method{sandbag}{ANY}(x, phases, gene.names=rownames(x),
     fraction=0.5, subset.row=NULL)
 
-\S4method{sandbag}{SingleCellExperiment}(x, phases, subset.row=NULL, ..., 
+\S4method{sandbag}{SingleCellExperiment}(x, phases, subset.row=NULL, ...,
     assay.type="counts", get.spikes=FALSE)
 }
 
@@ -25,14 +25,14 @@ This should typically be of length 3, with elements named as \code{"G1"}, \code{
 \item{fraction}{A numeric scalar specifying the minimum fraction to define a marker gene pair.}
 \item{subset.row}{A logical, integer or character scalar indicating the rows of \code{x} to use.}
 \item{...}{Additional arguments to pass to \code{sandbag,ANY-method}.}
-\item{assay.type}{A string specifying which assay values to use, e.g., \code{counts} or \code{exprs}.}
+\item{assay.type}{A string specifying which assay values to use, e.g., \code{counts} or \code{logcounts}.}
 \item{get.spikes}{A logical specifying whether spike-in transcripts should be used.}
 }
 
 \details{
 This function implements the training step of the pair-based prediction method described by Scialdone et al. (2015).
 Pairs of genes (A, B) are identified from a training data set where in each pair,
-    the fraction of cells in phase G1 with expression of A > B (based on expression values in \code{training.data}) 
+    the fraction of cells in phase G1 with expression of A > B (based on expression values in \code{training.data})
     and the fraction with B > A in each other phase exceeds \code{fraction}.
 These pairs are defined as the marker pairs for G1.
 This is repeated for each phase to obtain a separate marker pair set.
@@ -40,7 +40,7 @@ This is repeated for each phase to obtain a separate marker pair set.
 Pre-defined sets of marker pairs are provided for mouse and human (see Examples).
 The mouse set was generated as described by Scialdone et al. (2015), while the human training set was generated with data from Leng et al. (2015).
 Classification from test data can be performed using the \code{\link{cyclone}} function.
-For each cell, this involves comparing expression values between genes in each marker pair. 
+For each cell, this involves comparing expression values between genes in each marker pair.
 The cell is then assigned to the phase that is consistent with the direction of the difference in expression in the majority of pairs.
 
 For \code{sandbag,SingleCellExperiment-method}, the matrix of counts is used but can be replaced with expression values by setting \code{assays}.
@@ -51,7 +51,7 @@ Users can also manually select which rows to use via \code{subset.row}, which wi
 
 While \code{sandbag} and its partner function \code{\link{cyclone}} were originally designed for cell cyclone phase classification,
 the same computational strategy can be used to classify cells into any mutually exclusive groupings.
-Any number and nature of groups can be specified in \code{phases}, e.g., differentiation lineages, activation states. 
+Any number and nature of groups can be specified in \code{phases}, e.g., differentiation lineages, activation states.
 Only the names of \code{phases} need to be modified to reflect the biology being studied.
 }
 
@@ -86,7 +86,7 @@ hs.pairs <- readRDS(system.file("exdata", "human_cycle_markers.rds", package="sc
 }
 
 \references{
-Scialdone A, Natarajana KN, Saraiva LR et al. (2015). 
+Scialdone A, Natarajana KN, Saraiva LR et al. (2015).
 Computational assignment of cell-cycle stage from single-cell transcriptome data.
 \emph{Methods} 85:54--61
 

--- a/man/trendVar.Rd
+++ b/man/trendVar.Rd
@@ -7,10 +7,10 @@
 \description{Fit a mean-dependent trend to the gene-specific variances in single-cell RNA-seq data.}
 
 \usage{
-\S4method{trendVar}{ANY}(x, method=c("loess", "spline"), parametric=FALSE, 
+\S4method{trendVar}{ANY}(x, method=c("loess", "spline"), parametric=FALSE,
     loess.args=list(), spline.args=list(), nls.args=list(),
-    span=NULL, family=NULL, degree=NULL, df=NULL, start=NULL, 
-    min.mean=0.1, design=NULL, subset.row=NULL) 
+    span=NULL, family=NULL, degree=NULL, df=NULL, start=NULL,
+    min.mean=0.1, design=NULL, subset.row=NULL)
 
 \S4method{trendVar}{SingleCellExperiment}(x, subset.row=NULL, ..., assay.type="logcounts", use.spikes=TRUE)
 }
@@ -32,7 +32,7 @@
 \item{design}{A numeric matrix describing the uninteresting factors contributing to expression in each cell.}
 \item{subset.row}{A logical, integer or character scalar indicating the rows of \code{x} to use.}
 \item{...}{Additional arguments to pass to \code{trendVar,ANY-method}.}
-\item{assay.type}{A string specifying which assay values to use, e.g., \code{counts} or \code{exprs}.}
+\item{assay.type}{A string specifying which assay values to use, e.g., \code{counts} or \code{logcounts}.}
 \item{use.spikes}{A logical scalar specifying whether the trend should be fitted to variances for spike-in transcripts or endogenous genes.}
 }
 
@@ -67,10 +67,10 @@ Conversely, the parametric form is not exact, so the smoothers will model any re
 The \code{method} argument specifies the smoothing algorithm to be applied on the log-ratios/variances.
 By default, a robust loess curve is used for trend fitting via \code{\link{loess}}.
 This provides a fairly flexible fit while protecting against genes with very large or very small variances.
-Arguments to \code{\link{loess}} are specified with \code{loess.args}, with defaults of \code{span=0.3}, \code{family="symmetric"} and \code{degree=1} unless otherwise specified. 
+Arguments to \code{\link{loess}} are specified with \code{loess.args}, with defaults of \code{span=0.3}, \code{family="symmetric"} and \code{degree=1} unless otherwise specified.
 Some experimentation with these parameters may be required to obtain satisfactory results.
 
-If \code{method="spline"}, smoothing will instead be performed using the \code{\link{smooth.spline}} function 
+If \code{method="spline"}, smoothing will instead be performed using the \code{\link{smooth.spline}} function
 Arguments are specified with \code{spline.args}, with a default degrees of freedom of \code{df=4} unless otherwise specified.
 Splines can be more effective than loess at capturing smooth curves with strong non-linear gradients.
 
@@ -80,7 +80,7 @@ When extrapolating to values above the largest observed mean, the output functio
 }
 
 \section{Additional notes on row selection}{
-Spike-in transcripts can be selected in \code{trendVar,SingleCellExperiment-method} using the \code{use.spikes} method. 
+Spike-in transcripts can be selected in \code{trendVar,SingleCellExperiment-method} using the \code{use.spikes} method.
 \itemize{
 \item By default, \code{use.spikes=TRUE} which means that only rows labelled as spike-ins with \code{isSpike(x)} will be used.
 \item If \code{use.spikes=FALSE}, only the rows \emph{not} labelled as spike-ins will be used.
@@ -104,7 +104,7 @@ Obviously, the usefulness of the trend is dependent on the quality of the featur
 For example, the trend will not provide accurate estimates of the technical component if the coverage of all spike-ins is lower than that of endogenous genes.
 }
 
-\section{Warning on size factor centring}{ 
+\section{Warning on size factor centring}{
 If \code{assay.type="logcounts"}, \code{trendVar,SingleCellExperiment-method} will attempt to determine if the expression values were computed from counts via \code{\link[scater]{normalize}}.
 If so, a warning will be issued if the size factors are not centred at unity.
 This is because different size factors are typically used for endogenous genes and spike-in transcripts.
@@ -157,7 +157,7 @@ Aaron Lun
 example(computeSpikeFactors) # Using the mocked-up data 'y' from this example.
 
 # Normalizing (gene-based factors for genes, spike-in factors for spike-ins)
-y <- computeSumFactors(y) 
+y <- computeSumFactors(y)
 y <- computeSpikeFactors(y, general.use=FALSE)
 y <- normalize(y)
 
@@ -166,14 +166,14 @@ fit <- trendVar(y)
 plot(fit$mean, fit$var)
 curve(fit$trend(x), col="red", lwd=2, add=TRUE)
 
-# Fitting a trend to the endogenous genes. 
+# Fitting a trend to the endogenous genes.
 fit.g <- trendVar(y, use.spikes=FALSE)
 plot(fit.g$mean, fit.g$var)
 curve(fit.g$trend(x), col="red", lwd=2, add=TRUE)
 }
 
 \references{
-Lun ATL, McCarthy DJ and Marioni JC (2016). 
+Lun ATL, McCarthy DJ and Marioni JC (2016).
 A step-by-step workflow for low-level analysis of single-cell RNA-seq data with Bioconductor.
 \emph{F1000Res.} 5:2122
 


### PR DESCRIPTION
During the EuroBioc, I just ended up reading through the docs and spotted this potential minor update.

I remember that at the Boston BioC conference, some discussion took place regarding which convenience accessors to keep/deprecate for the `SingleCellExperiment` class.
I saw that `scater` currently enables the accessors:
`c("exprs", "norm_exprs", "stand_exprs", "fpkm")`

While I think it's nice to keep the `exprs` accessor for backward compatibility to the 'main' assay matrix (_i.e._, `ExpressionSet`, `SCESet`), I saw that in this case it is systematically redirected to the `logcounts` accessor.
As a user, I would argue that it is more didactic to showcase the more direct `logcounts` accessor in the help pages and examples, even if the `exprs` is still offered. Just so that users more clearly know what slot they're accessing. (Alternatively, `exprs` could throw a warning that it accesses an assay named differently to the function, as it is the only exception).

Dropbox links:
* R CMD [check](https://www.dropbox.com/s/pjh57h9nnriefwp/scran_check.log?dl=0)
* R CMD [BiocCheck](https://www.dropbox.com/s/p67epl21kbh3bms/scran_BiocCheck.log?dl=0)

Note that this pull request also includes some automatic RStudio formatting that I didn't bother turn off (mostly trimmed spaces at ends of lines).

Please feel free to decline the pull request, if undesirable. I just thought I'd offer a user's perspective!

Thanks for the hard work!