### PR TITLE
Add option for tricube doublet kernel

### DIFF
--- a/R/doubletCells.R
+++ b/R/doubletCells.R
@@ -154,6 +154,7 @@ NULL
     dist2nth <- pmax(1e-8, median(self.dist))
 
     if(use.tricube.kernel){
+        self.dist <- findNeighbors(threshold=dist2nth, BNINDEX=pre.pcs, BNPARAM=BNPARAM, BPPARAM=BPPARAM, get.index=FALSE)$distance
         sim.dist <- queryNeighbors(sim.pcs, query=pcs, threshold=dist2nth, BNPARAM=BNPARAM, BPPARAM=BPPARAM, get.index=FALSE)$distance
         rel.dens <- bpmapply(FUN=function(self, sim, limit) {
              sum((1 - (sim/limit)^3)^3)/sum((1 - (self/limit)^3)^3)^2

--- a/man/doubletCells.Rd
+++ b/man/doubletCells.Rd
@@ -20,6 +20,7 @@ doubletCells(x, ...)
   force.match = FALSE,
   force.k = 20,
   force.ndist = 3,
+  use.tricube.kernel = FALSE,
   BNPARAM = KmknnParam(),
   BSPARAM = bsparam(),
   BPPARAM = SerialParam()
@@ -61,6 +62,8 @@ This is orthogonal to the values in \code{size.factors.norm}, see Details.}
 
 \item{force.ndist}{A numeric scalar specifying the bandwidth for remapping if \code{force.match=TRUE}.}
 
+\item{use.tricube.kernel}{A boolean value indicating whether or not to scale contributions to density using a tricube kernel.}
+
 \item{BNPARAM}{A \linkS4class{BiocNeighborParam} object specifying the nearest neighbor algorithm.
 This should be an algorithm supported by \code{\link{findNeighbors}}.}
 
@@ -84,7 +87,10 @@ Thus, the doublet score for each cell is defined as the ratio of densities of si
 
 Densities are calculated in low-dimensional space after a PCA on the log-normalized expression matrix of \code{x}.
 Simulated doublets are projected into the low-dimensional space using the rotation vectors computed from the original cells.
-A tricube kernel is used to compute the density around each cell.
+The numbers of original cells and simulated doublets close to each cell are counted, where "closeness" is defined as the median distance to the \code{k} nearest neighbour across all cells
+Densities are then computed for cell, as the fraction of simulated doublets that were close to the cell in question, divided by the squared fraction of all original cells that were close.
+Alternatively, if \code{use.tricube.kernel} is \code{TRUE}, a tricube kernel is used to compute the density around each cell. 
+This downweights the density contribution of original cells and simulated doublets if they are further from the cell in question.
 The bandwidth of the kernel is set to the median distance to the \code{k} nearest neighbour across all cells.
 
 The two size factor arguments have different roles:


### PR DESCRIPTION
I've restored the option to use the tricube kernel here, as well as making a small change to the documentation that covers (what I think is) the newer approach.

I've not been able to test this, as I don't have a suitable R environment installed, and I'm not inclined to make one! However, the changes are small, and default behaviour really ought to be unaffected. I'm hoping it might be easy on your end to give it a whirl?

I'm not sure if you'll be happy with ending the function with a big if/else block - let me know if there is a more elegant solution, short of pulling out the blocks into a separate function.