### PR TITLE
decideTestsPerLable() ignores value of pval.field

### DIFF
--- a/R/decideTestsPerLabel.R
+++ b/R/decideTestsPerLabel.R
@@ -53,7 +53,7 @@ decideTestsPerLabel <- function(results, method=c("separate", "global"), thresho
     pval.field="PValue", lfc.field="logFC") 
 {
     method <- match.arg(method)
-    all.p <- lapply(results, "[[", i="PValue")
+    all.p <- lapply(results, "[[", i=pval.field)
 
     if (method=="separate") {
         all.p <- lapply(all.p, p.adjust, method="BH")

--- a/R/decideTestsPerLabel.R
+++ b/R/decideTestsPerLabel.R
@@ -13,6 +13,7 @@
 #' or separately within each label.
 #' @param threshold Numeric scalar specifying the FDR threshold to consider genes as significant.
 #' @param pval.field String containing the name of the column containing the p-value in each entry of \code{results}.
+#' Defaults to \code{"PValue"}, \code{"P.Value"} or \code{"p.value"} based on fields in the first entry of \code{results}.
 #' @param lfc.field String containing the name of the column containing the log-fold change.
 #' Ignored if the column is not available Defaults to \code{"logFC"} if this field is available.
 #' @param ... Further arguments to pass to \code{decideTestsPerLabel} if \code{results} is a List.
@@ -50,9 +51,17 @@
 #' @export
 #' @importFrom stats p.adjust
 decideTestsPerLabel <- function(results, method=c("separate", "global"), threshold=0.05, 
-    pval.field="PValue", lfc.field="logFC") 
+    pval.field=NULL, lfc.field="logFC") 
 {
     method <- match.arg(method)
+
+    if (is.null(pval.field)) {
+        pval.field <- intersect(c("PValue", "P.Value", "p.value"), colnames(results[[1]]))
+        if (length(pval.field)==0) {
+            stop("could not automatically determine 'pval.field'")
+        }
+        pval.field <- pval.field[1]
+    }
     all.p <- lapply(results, "[[", i=pval.field)
 
     if (method=="separate") {

--- a/man/decideTestsPerLabel.Rd
+++ b/man/decideTestsPerLabel.Rd
@@ -9,7 +9,7 @@ decideTestsPerLabel(
   results,
   method = c("separate", "global"),
   threshold = 0.05,
-  pval.field = "PValue",
+  pval.field = NULL,
   lfc.field = "logFC"
 )
 
@@ -27,7 +27,8 @@ or separately within each label.}
 
 \item{threshold}{Numeric scalar specifying the FDR threshold to consider genes as significant.}
 
-\item{pval.field}{String containing the name of the column containing the p-value in each entry of \code{results}.}
+\item{pval.field}{String containing the name of the column containing the p-value in each entry of \code{results}.
+Defaults to \code{"PValue"}, \code{"P.Value"} or \code{"p.value"} based on fields in the first entry of \code{results}.}
 
 \item{lfc.field}{String containing the name of the column containing the log-fold change.
 Ignored if the column is not available Defaults to \code{"logFC"} if this field is available.}

--- a/tests/testthat/test-pseudo-dge.R
+++ b/tests/testthat/test-pseudo-dge.R
@@ -292,4 +292,19 @@ test_that("decideTestsPerLabel works correctly", {
     }
     dt02 <- decideTestsPerLabel(out)
     expect_identical(dt02, dt0)
+
+    # Works automatically with voom.
+    out <- pseudoBulkDGE(pseudo,
+        label=pseudo$cluster,
+        design=~DRUG,
+        coef="DRUG2",
+        method="voom"
+    )
+
+    dt <- decideTestsPerLabel(out)
+    dtp <- decideTestsPerLabel(out, pval.field="P.Value")
+    expect_identical(dt, dtp)
+
+    colnames(out[[1]]) <- head(LETTERS, ncol(out[[1]]))
+    expect_error(decideTestsPerLabel(out), "pval.field")
 })


### PR DESCRIPTION
Mind porting the fix to the release branch, please? FYI I hit this because `scran::pseudBulkDGE(..., method = "voom")` has `P.Value` as the relevant field.