### PR TITLE
Fall back to combining pure one-sided tests for direction=any.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scran
-Version: 1.19.15
-Date: 2021-03-07
+Version: 1.19.16
+Date: 2021-03-12
 Title: Methods for Single-Cell RNA-Seq Data Analysis
 Description: 
     Implements miscellaneous functions for interpretation of single-cell RNA-seq data.

--- a/R/pairwiseBinom.R
+++ b/R/pairwiseBinom.R
@@ -306,21 +306,8 @@ setMethod("pairwiseBinom", "SingleCellExperiment", function(x, groups=colLabels(
             valid=host.n > 0L && target.n > 0L
         )
 
-        left.lower <- pbinom(host.nzero, size, p.left, log.p=TRUE)
-        right.upper <- pbinom(host.nzero - 1, size, p.right, lower.tail=FALSE, log.p=TRUE)
-
-        if (direction=="any") {
-            left.upper <- pbinom(host.nzero, size, p.right, log.p=TRUE)
-            right.lower <- pbinom(host.nzero - 1, size, p.left, lower.tail=FALSE, log.p=TRUE)
-
-            # Here, the null hypothesis is that the shift is evenly distributed at 50%
-            # probability for -lfc and lfc, hence we take the average of the two p-values.
-            output$left <- .add_log_values(left.lower, left.upper) - log(2)
-            output$right <- .add_log_values(right.lower, right.upper) - log(2)
-        } else {
-            output$left <- left.lower
-            output$right <- right.upper
-        }
+        output$left <- pbinom(host.nzero, size, p.left, log.p=TRUE)
+        output$right <- pbinom(host.nzero - 1, size, p.right, lower.tail=FALSE, log.p=TRUE)
 
         output
     }

--- a/R/pairwiseTTests.R
+++ b/R/pairwiseTTests.R
@@ -438,28 +438,15 @@ setMethod("pairwiseTTests", "SingleCellExperiment", function(x, groups=colLabels
         left <- pt(cur.t, df=cur.df, lower.tail=TRUE, log.p=TRUE)
         right <- pt(cur.t, df=cur.df, lower.tail=FALSE, log.p=TRUE)
     } else {
-        upper.t <- (cur.lfc - thresh.lfc)/sqrt(cur.err)
+        # For one-sided tests, testing against the lfc threshold in the specified direction.
+        # Note that if direction='up', only 'right' is used; nonetheless, 'left' is still calculated
+        # using 'lower.t' so as to allow quick calculation of the p-value for the reversed contrast,
+        # by simply swapping 'left' and 'right'. The same applies when direction='down'.
         lower.t <- (cur.lfc + thresh.lfc)/sqrt(cur.err)
+        left <- pt(lower.t, df=cur.df, lower.tail=TRUE, log.p=TRUE)
 
-        left.lower <- pt(lower.t, df=cur.df, lower.tail=TRUE, log.p=TRUE)
-        right.upper <- pt(upper.t, df=cur.df, lower.tail=FALSE, log.p=TRUE)
-
-        if (direction=="any") {
-            # Using the TREAT method, which tests against a null where the log-fold change is
-            # takes values at the extremes of [-thresh, thresh]. The null probability is 50%
-            # distributed across both extremes, hence the -log(2) at the end.
-            left.upper <- pt(upper.t, df=cur.df, lower.tail=TRUE, log.p=TRUE)
-            right.lower <- pt(lower.t, df=cur.df, lower.tail=FALSE, log.p=TRUE)
-            left <- .add_log_values(left.upper, left.lower) - log(2)
-            right <- .add_log_values(right.upper, right.lower) - log(2)
-        } else {
-            # For one-sided tests, testing against the lfc threshold in the specified direction.
-            # Note that if direction='up', only 'right' is used; nonetheless, 'left' is still calculated
-            # using 'lower.t' so as to allow quick calculation of the p-value for the reversed contrast,
-            # by simply swapping 'left' and 'right'. The same applies when direction='down'.
-            left <- left.lower
-            right <- right.upper
-        }
+        upper.t <- (cur.lfc - thresh.lfc)/sqrt(cur.err)
+        right <- pt(upper.t, df=cur.df, lower.tail=FALSE, log.p=TRUE)
     }
 
     list(left=left, right=right)

--- a/R/pairwiseTTests.R
+++ b/R/pairwiseTTests.R
@@ -273,7 +273,7 @@ setMethod("pairwiseTTests", "SingleCellExperiment", function(x, groups=colLabels
         cur.err <- t.out$err
         cur.df <- t.out$test.df
         cur.lfc <- out.means[[b]][,host] - out.means[[b]][,target]
-        p.out <- .run_t_test(cur.lfc, cur.err, cur.df, thresh.lfc=lfc, direction=direction)
+        p.out <- .run_t_test(cur.lfc, cur.err, cur.df, thresh.lfc=lfc) 
 
         effect.size <- cur.lfc
         if (std.lfc) {
@@ -398,7 +398,7 @@ setMethod("pairwiseTTests", "SingleCellExperiment", function(x, groups=colLabels
             target <- clust.vals[tdex]
             cur.lfc <- ref.coef - coefficients[,tdex]
 
-            test.out <- .run_t_test(cur.lfc, lfit2$stdev.unscaled[tdex]^2*sigma2, resid.df, thresh.lfc=lfc, direction=direction)
+            test.out <- .run_t_test(cur.lfc, lfit2$stdev.unscaled[tdex]^2*sigma2, resid.df, thresh.lfc=lfc)
             hvt.p <- .choose_leftright_pvalues(test.out$left, test.out$right, direction=direction)
             tvh.p <- .choose_leftright_pvalues(test.out$right, test.out$left, direction=direction)
 
@@ -428,7 +428,7 @@ setMethod("pairwiseTTests", "SingleCellExperiment", function(x, groups=colLabels
 ###########################################################
 
 #' @importFrom stats pt
-.run_t_test <- function(cur.lfc, cur.err, cur.df, thresh.lfc=0, direction="any")
+.run_t_test <- function(cur.lfc, cur.err, cur.df, thresh.lfc=0) 
 # This runs the t-test given the relevant statistics, regardless of how
 # they were computed (i.e., within blocks, or in a linear model).
 {

--- a/R/pairwiseWilcox.R
+++ b/R/pairwiseWilcox.R
@@ -279,8 +279,9 @@ setMethod("pairwiseWilcox", "SingleCellExperiment", function(x, groups=colLabels
         z <- effect - cur.prod/2
         SIGMA <- .get_sigma(host.n, target.n, all.ties[[b]][[host]][,target])
 
-        # using 0.25 to avoid numerical imprecision; z should go up in units of 0.5's.
-        CORRECTION <- if (direction=="any") ifelse(abs(z) < 0.25, 0, 0.5) else 0.5 
+        # Always dealing with one-sided tests, so we fix the correction at 0.5
+        # rather than allowing it to be zero for direction='any' (as in wilcox.test()).
+        CORRECTION <- 0.5
         output$left <- pnorm((z + CORRECTION)/SIGMA, log.p=TRUE)
         output$right <- pnorm((z - CORRECTION)/SIGMA, log.p=TRUE, lower.tail=FALSE)
 

--- a/R/pairwiseWilcox.R
+++ b/R/pairwiseWilcox.R
@@ -306,11 +306,7 @@ setMethod("pairwiseWilcox", "SingleCellExperiment", function(x, groups=colLabels
         added.effect <- all.stats[[b]][[target]][,host]
 
         if (direction=="any") {
-            # Taking the average to ensure that the AUC is interpretable around 0.5. 
-            # This has the benefit that the effect size is agnostic to the setting of direction
-            # (which is necessary, as .pairwise_blocked_template() doesn't have any concept
-            # of choosing a different effect value according to the direction of change).
-            # Also see Details for an interpretation of what this actually means.
+            # Taking the average to ensure that the AUC is interpretable around 0.5, see Details.
             effect <- minus.effect/2 + added.effect/2
             auc <- effect/cur.prod
             output <- list(forward=auc, reverse=1-auc)
@@ -331,25 +327,13 @@ setMethod("pairwiseWilcox", "SingleCellExperiment", function(x, groups=colLabels
         added.SIGMA <- .get_sigma(host.n, target.n, all.ties[[b]][[target]][,host])
 
         CORRECTION <- 0.5
-        left.lower <- pnorm((added.z + CORRECTION)/added.SIGMA, log.p=TRUE)
-        right.upper <- pnorm((minus.z - CORRECTION)/minus.SIGMA, log.p=TRUE, lower.tail=FALSE)
 
-        if (direction=="any") {
-            left.upper <- pnorm((minus.z + CORRECTION)/minus.SIGMA, log.p=TRUE)
-            right.lower <- pnorm((added.z - CORRECTION)/added.SIGMA, log.p=TRUE, lower.tail=FALSE)
-
-            # Here, the null hypothesis is that the shift is evenly distributed at 50%
-            # probability for -lfc and lfc, hence we take the average of the two p-values.
-            output$left <- .add_log_values(left.lower, left.upper) - log(2)
-            output$right <- .add_log_values(right.lower, right.upper) - log(2)
-        } else {
-            # For one-sided tests, testing against the lfc threshold in the specified direction.
-            # Note that if direction='up', only 'right' is used; nonetheless, 'left' is still calculated
-            # so as to allow quick calculation of the p-value for the reversed contrast,
-            # by simply swapping 'left' and 'right'. The same applies when direction='down'.
-            output$left <- left.lower 
-            output$right <- right.upper
-        }
+        # For one-sided tests, testing against the lfc threshold in the specified direction.
+        # Note that if direction='up', only 'right' is used; nonetheless, 'left' is still calculated
+        # so as to allow quick calculation of the p-value for the reversed contrast,
+        # by simply swapping 'left' and 'right'. The same applies when direction='down'.
+        output$left <- pnorm((added.z + CORRECTION)/added.SIGMA, log.p=TRUE)
+        output$right <- pnorm((minus.z - CORRECTION)/minus.SIGMA, log.p=TRUE, lower.tail=FALSE)
 
         output
     }

--- a/R/utils_markers.R
+++ b/R/utils_markers.R
@@ -139,7 +139,7 @@
     } else if (direction=="down") {
         return(left)
     } else {
-        # The x2 can also be interpreted as a Bonferroni correction,
+        # The doubling can also be interpreted as a Bonferroni correction,
         # and thus is valid even if the null regions are not symmetric.
         log.p.out <- pmin(left, right) + log(2)
         return(pmin(0, log.p.out)) 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -26,6 +26,9 @@ Soft-deprecated existing functions.
 \item Added \code{fixedPCA()} to compute a PCA with a fixed number of components, a la \code{scater::runPCA()} (but without requiring \pkg{scater}).
 
 \item Modified \code{denoisePCA()} so that it now complains if \code{subset.row=} is not provided.
+
+\item Modified all \code{pairwise*} functions so that the p-value from \code{direction="any"} is derived from the two p-values from the one-sided tests.
+This is necessary for correctness with all choices of \code{lfc=} and \code{block=}, at the cost of conservativeness when \code{block=NULL} and \code{lfc} is large.
 }}
 
 \section{Version 1.18.0}{\itemize{


### PR DESCRIPTION
From discussion in #86.

This is unnecessarily conservative in the special case of `direction="any"`, `lfc >> 0` and `block=NULL`. But I don't want to handle that special case, and I can't figure out how to generalize the less-conservative approach to survive Stouffer's method.

In some respects, the conservativeness of the special case doesn't really matter, given how low the p-values are anyway.