### PR TITLE
add weights in pseudbulkDGE for edgeR analysis

### DIFF
--- a/R/pseudoBulkDGE.R
+++ b/R/pseudoBulkDGE.R
@@ -177,10 +177,10 @@ NULL
     
     # Checks on weights
     if(is.vector(weights)){
-      stopfinot(length(weights)==nrow(design))
+      stopifnot(length(weights)==nrow(design))
       weights <- matrix(weights,nrow=nrow(x), ncol=ncol(x), byrow=TRUE)
     } else if(is.matrix(weights)){
-      stopfinot(all.equal(dim(weights),dim(x)))
+      stopifnot(all.equal(dim(weights),dim(x)))
     }
 
     for (i in sort(unique(label))) {

--- a/R/pseudoBulkDGE.R
+++ b/R/pseudoBulkDGE.R
@@ -25,6 +25,8 @@
 #' @param row.data A \linkS4class{DataFrame} containing additional row metadata for each gene in \code{x},
 #' to be included in each of the output DataFrames.
 #' This should have the same number and order of rows as \code{x}.
+#' @param weights A vector or matrix of weights. If vector, it is assumed the weights are equal for all genes. Alternatively,
+#' a matrix with the same dimensions as \code{x} can be provided.
 #' @param ... For the generic, additional arguments to pass to individual methods.
 #'
 #' For the SummarizedExperiment method, additional arguments to pass to the ANY method.
@@ -188,6 +190,7 @@ NULL
         curdata <- col.data[chosen,,drop=FALSE]
         y <- DGEList(curx, samples=as.data.frame(curdata))
         curcond <- condition[chosen]
+        curweights <- weights[,chosen]
 
         curdesign <- try({
             if (is.function(design)) {
@@ -204,7 +207,7 @@ NULL
         } else {
             args <- list(y, row.names=rownames(x), curdesign=curdesign, curcond=curcond,
                 coef=coef, contrast=contrast, lfc=lfc, null.lfc=null.lfc.list[[i]],
-                robust=robust, include.intermediates=include.intermediates, weights=weights)
+                robust=robust, include.intermediates=include.intermediates, weights=curweights)
 
             if (method=="edgeR") {
                 stuff <- do.call(.pseudo_bulk_edgeR, args)

--- a/R/pseudoBulkDGE.R
+++ b/R/pseudoBulkDGE.R
@@ -251,7 +251,7 @@ NULL
     y <- y[gkeep,]
     y <- calcNormFactors(y)
 
-    if(!is.null(weights)) y$weights <- weights
+    if(!is.null(weights)) y$weights <- weights[gkeep,]
     
     rank <- qr(curdesign)$rank
     if (rank == nrow(curdesign) || rank < ncol(curdesign)) { 


### PR DESCRIPTION
Hi,

In some cases, one might want to add weights to the dispersion estimation and fitting of the edgeR model when using the `pseudobulkDGE` function. In my case this would be sample-level weights (much like voom with sample quality weights), but I imagine that observation-level weights may also be of interest, so I have allowed a matrix of weights that is of same dimension as the expression matrix. 
This seems to be possible using only a minor adjustment.

Let me know what you think.