### PR TITLE
fix error unused argument objective_function when pass both block and graph.fun

### DIFF
--- a/R/quickCluster.R
+++ b/R/quickCluster.R
@@ -157,8 +157,8 @@ NULL
 
         collected <- bpmapply(FUN=.quick_cluster, x.by.block, 
             MoreArgs=list(min.size=min.size, method=method, use.ranks=use.ranks,
-                subset.row=subset.row, min.mean=min.mean, 
-                BSPARAM=BSPARAM, BPPARAM=BPPARAM, ...), 
+                d = d, subset.row=subset.row, min.mean=min.mean, 
+                graph.fun = graph.fun, BSPARAM=BSPARAM, BPPARAM=BPPARAM, ...), 
             BPPARAM=block.BPPARAM)
 
         # Merging the results across different blocks.


### PR DESCRIPTION
When pass block and graph.fun function, the graph.fun won't be passed bo the nested `.quick_cluster` function
```
scran::quickCluster(
        sce_object,
        d = 50L,
        graph.fun = "leiden",
        k = 15L, type = "jaccard",
        cluster.args = list(
            objective_function = "modularity",
            resolution_parameter = 0.8,
            n_iterations = -1L # undocumented characteristics
        ),
        block = sce_object$title,
        BSPARAM = BiocSingular::IrlbaParam()
)
```
![image](https://user-images.githubusercontent.com/19575010/230781015-03ea8881-dc41-4841-baba-b0c28c5540d8.png)