### PR TITLE
Overflow fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: scran
-Version: 1.39.0
-Date: 2024-09-05
+Version: 1.39.1
+Date: 2026-02-25
 Title: Methods for Single-Cell RNA-Seq Data Analysis
 Description: 
     Implements miscellaneous functions for interpretation of single-cell RNA-seq data.

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,7 +3,7 @@
 \encoding{UTF-8}
 
 \section{Version 1.40}{\itemize{
-\item Bugfix for \code{overlapExprs()} to avoid integer overflow with large numbers of ties.
+\item Bugfix for the AUC calculations in \code{pairwiseWilcox()} and \code{scoreMarkers()}, to avoid integer overflow with large numbers of ties.
 }}
 
 \section{Version 1.34}{\itemize{

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -2,6 +2,10 @@
 \title{scran News}
 \encoding{UTF-8}
 
+\section{Version 1.40}{\itemize{
+\item Bugfix for \code{overlapExprs()} to avoid integer overflow with large numbers of ties.
+}}
+
 \section{Version 1.34}{\itemize{
 \item Bugfix for \code{quickCluster()} to pass along arguments to the internal per-block call.
 }}

--- a/src/overlap_exprs.cpp
+++ b/src/overlap_exprs.cpp
@@ -59,7 +59,7 @@ public:
         return;
     }
 
-    std::pair<double, int> contrast_groups(int left, int right, double shift) const {
+    std::pair<double, double> contrast_groups(int left, int right, double shift) const {
         const auto& group1 = by_group[left];
         const int nelements1 = nelements[left];
         const auto& group2 = by_group[right];


### PR DESCRIPTION
Changed return type of wilcoxer contrast_groups from std::pair<double, int> to std::pair<double, double> . Fixes MarioniLab/scran#125